### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,35 +12,35 @@ Nokia_3310_LCD	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-writeCommand		KEYWORD2
-writeData		KEYWORD2
-write			KEYWORD2
-init			KEYWORD2
-clear			KEYWORD2
-gotoXY			KEYWORD2
-update			KEYWORD2
-writeString		KEYWORD2
-writeStringP		KEYWORD2
-writeStringBig		KEYWORD2
-writeCharBig		KEYWORD2
-writeChar		KEYWORD2
-drawBitmap		KEYWORD2
-drawBitmapP		KEYWORD2
-clearBitmap		KEYWORD2
-setPixel		KEYWORD2
-drawLine		KEYWORD2
-drawRectangle		KEYWORD2
+writeCommand	KEYWORD2
+writeData	KEYWORD2
+write	KEYWORD2
+init	KEYWORD2
+clear	KEYWORD2
+gotoXY	KEYWORD2
+update	KEYWORD2
+writeString	KEYWORD2
+writeStringP	KEYWORD2
+writeStringBig	KEYWORD2
+writeCharBig	KEYWORD2
+writeChar	KEYWORD2
+drawBitmap	KEYWORD2
+drawBitmapP	KEYWORD2
+clearBitmap	KEYWORD2
+setPixel	KEYWORD2
+drawLine	KEYWORD2
+drawRectangle	KEYWORD2
 drawFilledRectangle	KEYWORD2
-drawCircle		KEYWORD2
-get_key			KEYWORD2
+drawCircle	KEYWORD2
+get_key	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-MENU_NORMAL		LITERAL1
-MENU_HIGHLIGHT		LITERAL1
-PIXEL_OFF		LITERAL1
-PIXEL_ON		LITERAL1
-PIXEL_XOR		LITERAL1
+MENU_NORMAL	LITERAL1
+MENU_HIGHLIGHT	LITERAL1
+PIXEL_OFF	LITERAL1
+PIXEL_ON	LITERAL1
+PIXEL_XOR	LITERAL1
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords